### PR TITLE
fix TestProduceConsume failing on message decode. close #8

### DIFF
--- a/jocko/server_test.go
+++ b/jocko/server_test.go
@@ -234,7 +234,11 @@ func TestConsumerGroup(t *testing.T) {
 			r.Fatalf("err: %v", err)
 		}
 		if 3 != len(client.Brokers()) {
-			r.Fatalf("client didn't find the right number of brokers: got %d, want %d", len(client.Brokers()), 3)
+			r.Fatalf(
+				"client didn't find the right number of brokers: got %d, want %d",
+				len(client.Brokers()),
+				3,
+			)
 		}
 	})
 

--- a/protocol/produce_request.go
+++ b/protocol/produce_request.go
@@ -51,9 +51,11 @@ func (r *ProduceRequest) Encode(e PacketEncoder) (err error) {
 
 func (r *ProduceRequest) Decode(d PacketDecoder, version int16) (err error) {
 	r.APIVersion = version
-	r.TransactionalID, err = d.NullableString()
-	if err != nil {
-		return err
+	if r.APIVersion >= 3 {
+		r.TransactionalID, err = d.NullableString()
+		if err != nil {
+			return err
+		}
 	}
 
 	r.Acks, err = d.Int16()


### PR DESCRIPTION
Added version check to produceRequest.Decode analog to produceRequest.Encode.